### PR TITLE
fix : 회원탈퇴 관련 코드 수정

### DIFF
--- a/src/main/java/com/example/newsfeed/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeed/post/entity/Post.java
@@ -1,10 +1,13 @@
 package com.example.newsfeed.post.entity;
 
+import com.example.newsfeed.comment.entity.Comment;
 import com.example.newsfeed.common.entity.BaseEntity;
 import com.example.newsfeed.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 
 @Table(name = "post")
@@ -26,6 +29,9 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    private List<Comment> comments;
 
     public Post(String title, String content, User user) {
         this.title = title;

--- a/src/main/java/com/example/newsfeed/user/controller/LoginController.java
+++ b/src/main/java/com/example/newsfeed/user/controller/LoginController.java
@@ -6,7 +6,6 @@ import com.example.newsfeed.user.dto.login.LoginResponseDto;
 import com.example.newsfeed.user.entity.User;
 import com.example.newsfeed.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/newsfeed/user/entity/User.java
+++ b/src/main/java/com/example/newsfeed/user/entity/User.java
@@ -1,6 +1,10 @@
 package com.example.newsfeed.user.entity;
 
+import com.example.newsfeed.comment.entity.Comment;
 import com.example.newsfeed.common.entity.BaseEntity;
+import com.example.newsfeed.friend.entity.Friend;
+import com.example.newsfeed.friend.entity.FriendsRequest;
+import com.example.newsfeed.like.entity.Likes;
 import com.example.newsfeed.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -8,6 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -28,6 +33,23 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private String password;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Post> posts;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Likes> likes;
+
+    @OneToMany(mappedBy = "requester", cascade = CascadeType.ALL)
+    private List<FriendsRequest> sentFriendsRequests;
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
+    private List<FriendsRequest> receiveFriendsRequests;
+
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.REMOVE)
+    private List<Friend> receiveFriends;
+    @OneToMany(mappedBy = "requester", cascade = CascadeType.REMOVE)
+    private List<Friend> requesterFriends;
+
 
     public User(String email, String password, String name) {
         this.email = email;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,10 +3,10 @@ spring.application.name=newsFeed
 spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
 spring.datasource.username=root
 
-spring.datasource.password=0000
+spring.datasource.password=1935
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
회원이 탈퇴하려면 자식 테이블들이 존재할때 외래키 참조 조약 때문에 삭제가 안되던 문제를 해결하였습니다. oneToMany 로 양방향 매핑 후 Cascade.ALL 혹은 Cascade.Remove 를 추가하는 형식으로 해결했습니다.